### PR TITLE
Increase max toons from 8 to 12

### DIFF
--- a/app/context/ToonContext.tsx
+++ b/app/context/ToonContext.tsx
@@ -15,7 +15,7 @@ type ToonContextType = {
   setActiveIndex: (index: number) => void;
 };
 
-const MAX_TOONS = 8;
+const MAX_TOONS = 12;
 const LOCAL_STORAGE_KEY = "toonData";
 const ACTIVE_KEY = "activeIndex";
 


### PR DESCRIPTION
Summary
- Increased the max allowed toons from 8 to 12 in `ToonContext.tsx`.
- Did a minor constant change
