### PR TITLE
fix(Relevant-Invasion-Toast): replace getCogIcon with getCogImage

### DIFF
--- a/app/components/Home/tabs/components/useInvasionNotifications.tsx
+++ b/app/components/Home/tabs/components/useInvasionNotifications.tsx
@@ -6,14 +6,9 @@ import { useToonContext } from "@/app/context/ToonContext";
 import {
   getRelevantInvasionsForTasks,
   sanitizeCogName,
+  getCogImage,
 } from "@/app/utils/invasionUtils";
 import InvasionToast from "@/app/components/InvasionToast";
-
-function getCogIcon(cogName: string) {
-  if (!cogName) return undefined;
-  const sanitized = sanitizeCogName(cogName).replace(/ /g, "_").toLowerCase();
-  return `/cog_images/${sanitized}.png`;
-}
 
 function playNotificationSound(repeat: number, interval: number) {
   let played = 0;
@@ -88,7 +83,7 @@ export function useInvasionNotifications({
     ) => {
       if (options.showToast) {
         setToastMsg(msg);
-        setCogIcon(cogs.length === 1 ? getCogIcon(cogs[0]) : undefined);
+        setCogIcon(cogs.length === 1 ? getCogImage(cogs[0]) : undefined);
         setShowToast(true);
       }
       if (options.playSound && options.repeat && options.repeat > 0) {


### PR DESCRIPTION
- Relevant Invasion Toast was not loading correct image for some cogs.

Example Bug:
<img width="428" alt="image" src="https://github.com/user-attachments/assets/cc21df28-9e87-4846-ab91-6c24942b7515" />

Fixed:
<img width="521" alt="image" src="https://github.com/user-attachments/assets/df44201d-ec13-4c4b-b94f-99b1927d5c58" />

