### PR TITLE
feat(InvasionsTab): Push relevant invasions to top of invasions list

### DIFF
--- a/app/components/Home/tabs/InvasionsTab.tsx
+++ b/app/components/Home/tabs/InvasionsTab.tsx
@@ -48,16 +48,13 @@ const InvasionsTab: React.FC<TabProps> = ({ toon }) => {
   const sortedInvasions = useMemo(() => {
     if (!relevantInvasions.length) return displayedInvasions;
     const relevantKeys = new Set(
-      relevantInvasions.map(
-        (inv) => `${inv.cog}|${inv.district}|${inv.startTimestamp}`
-      )
+      relevantInvasions.map((inv) => `${inv.cog}|${inv.district}`)
     );
     const relevant = displayedInvasions.filter((inv) =>
-      relevantKeys.has(`${inv.cog}|${inv.district}|${inv.startTimestamp}`)
+      relevantKeys.has(`${inv.cog}|${inv.district}`)
     );
     const others = displayedInvasions.filter(
-      (inv) =>
-        !relevantKeys.has(`${inv.cog}|${inv.district}|${inv.startTimestamp}`)
+      (inv) => !relevantKeys.has(`${inv.cog}|${inv.district}`)
     );
     return [...relevant, ...others];
   }, [displayedInvasions, relevantInvasions]);
@@ -92,9 +89,7 @@ const InvasionsTab: React.FC<TabProps> = ({ toon }) => {
               const elapsedMs = now - invasion.startTimestamp * 1000;
               const isRelevant = relevantInvasions.some(
                 (rel) =>
-                  rel.cog === invasion.cog &&
-                  rel.district === invasion.district &&
-                  rel.startTimestamp === invasion.startTimestamp
+                  rel.cog === invasion.cog && rel.district === invasion.district
               );
               return (
                 <motion.div

--- a/app/components/Home/tabs/InvasionsTab.tsx
+++ b/app/components/Home/tabs/InvasionsTab.tsx
@@ -44,6 +44,24 @@ const InvasionsTab: React.FC<TabProps> = ({ toon }) => {
     );
   }, [toon, displayedInvasions]);
 
+  // Resort invasions: relevant at the top
+  const sortedInvasions = useMemo(() => {
+    if (!relevantInvasions.length) return displayedInvasions;
+    const relevantKeys = new Set(
+      relevantInvasions.map(
+        (inv) => `${inv.cog}|${inv.district}|${inv.startTimestamp}`
+      )
+    );
+    const relevant = displayedInvasions.filter((inv) =>
+      relevantKeys.has(`${inv.cog}|${inv.district}|${inv.startTimestamp}`)
+    );
+    const others = displayedInvasions.filter(
+      (inv) =>
+        !relevantKeys.has(`${inv.cog}|${inv.district}|${inv.startTimestamp}`)
+    );
+    return [...relevant, ...others];
+  }, [displayedInvasions, relevantInvasions]);
+
   // Helper to parse progress string like "123/500"
   function parseProgress(progress: string) {
     const match = progress.match(/(\d+)\s*\/\s*(\d+)/);
@@ -68,7 +86,7 @@ const InvasionsTab: React.FC<TabProps> = ({ toon }) => {
           <div className="text-center">Loading...</div>
         ) : displayedInvasions.length > 0 ? (
           <AnimatePresence initial={false}>
-            {displayedInvasions.map((invasion) => {
+            {sortedInvasions.map((invasion) => {
               const { current, total } = parseProgress(invasion.progress);
               const percent = Math.floor((current / total) * 100);
               const elapsedMs = now - invasion.startTimestamp * 1000;


### PR DESCRIPTION
- Simply resorts invasions list and puts relevant ones at the top, Closes #78 
![image](https://github.com/user-attachments/assets/8cd1f9cd-d8b0-4b2d-ae98-3f21ab585874)
